### PR TITLE
added instructions for running the tests, and made the tests config simpler

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
 include AUTHORS.rst
 include CONTRIBUTING.rst
-include HISTORY.rst
+include HISTORY.md
 include LICENSE
-include README.rst
+include README.md
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/README.md
+++ b/README.md
@@ -20,3 +20,18 @@ Adds or modifies the git `commit-msg` hook at `.git/hooks/commit-msg` to execute
 
 ## Usage Guide
 * [Heroku + CircleCI](./examples/heroku/)
+
+## Running tests
+1. Ensure `tox` is installed with `pip install tox`
+2. Use `tox` to run tests against py2.7 and py3.5.
+    3. _You can also run `py.test` in the project root to run against   your environment's python._
+3. Rentlytics employees can run `make release` to push to PyPi.  In order to authenticate, you need a `.pypirc` file in your home directory
+### Tests Structre
+The tests folder contains a Django project with 3 apps:
+
+* conflicting_migrations
+* safe_migrations
+* unsafe_migrations
+
+These apps provide test coverage for different scenarios of migrations to test, they only contain the minimum required files (`models.py` and a `migrations` folder) to act as a Django app.  Tests use different combinations of these apps to simulate realistic migration scenarios for testing.
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=settings
-addopts=-s -vv
+DJANGO_SETTINGS_MODULE=tests.settings
+addopts=-s -vv tests/
 pep8maxlinelength = 120

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,8 @@
+bumpversion==0.5.3
+flake8==2.4.1
+tox==2.5.0
 coverage==4.2
-invoke==0.13.0
-pytest
-pytest-django
+Sphinx==1.3.1
+pytest==3.0.5
+pytest-cov==2.4.0
+pytest-django==3.1.2

--- a/setup.py
+++ b/setup.py
@@ -2,98 +2,13 @@
 # -*- coding: utf-8 -*-
 
 
-import os
-import sys
-from distutils.util import convert_path
-from fnmatch import fnmatchcase
-
-from setuptools import setup, find_packages
+from setuptools import setup
 
 with open('README.md') as readme_file:
     readme = readme_file.read()
 
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
-
-# Provided as an attribute, so you can append to these instead
-# of replicating them:
-standard_exclude = ('*.py', '*.pyc', '*$py.class', '*~', '.*', '*.bak')
-standard_exclude_directories = ('.*', 'CVS', '_darcs', './build',
-                                './dist', 'EGG-INFO', '*.egg-info', '__pycache__')
-
-
-# (c) 2005 Ian Bicking and contributors; written for Paste (http://pythonpaste.org)
-# Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
-# Note: you may want to copy this into your setup.py file verbatim, as
-# you can't import this from another package, when you don't know if
-# that package is installed yet.
-def find_package_data(where='.', package='',
-                      exclude=standard_exclude,
-                      exclude_directories=standard_exclude_directories,
-                      only_in_packages=True,
-                      show_ignored=False):
-    """
-    Return a dictionary suitable for use in ``package_data``
-    in a distutils ``setup.py`` file.
-    The dictionary looks like::
-        {'package': [files]}
-    Where ``files`` is a list of all the files in that package that
-    don't match anything in ``exclude``.
-    If ``only_in_packages`` is true, then top-level directories that
-    are not packages won't be included (but directories under packages
-    will).
-    Directories matching any pattern in ``exclude_directories`` will
-    be ignored; by default directories with leading ``.``, ``CVS``,
-    and ``_darcs`` will be ignored.
-    If ``show_ignored`` is true, then all the files that aren't
-    included in package data are shown on stderr (for debugging
-    purposes).
-    Note patterns use wildcards, or can be exact paths (including
-    leading ``./``), and all searching is case-insensitive.
-    """
-
-    out = {}
-    stack = [(convert_path(where), '', package, only_in_packages)]
-    while stack:
-        where, prefix, package, only_in_packages = stack.pop(0)
-        for name in os.listdir(where):
-            fn = os.path.join(where, name)
-            if os.path.isdir(fn):
-                bad_name = False
-                for pattern in exclude_directories:
-                    if fnmatchcase(name, pattern) or fn.lower() == pattern.lower():
-                        bad_name = True
-                        if show_ignored:
-                            print(sys.stderr, (
-                                "Directory %s ignored by pattern %s"
-                                % (fn, pattern)))
-                        break
-                if bad_name:
-                    continue
-                if (os.path.isfile(os.path.join(fn, '__init__.py')) and not prefix):
-                    if not package:
-                        new_package = name
-                    else:
-                        new_package = package + '.' + name
-                    stack.append((fn, '', new_package, False))
-                else:
-                    stack.append((fn, prefix + name + '/', package, only_in_packages))
-            elif package or not only_in_packages:
-                # is a file
-                bad_name = False
-                for pattern in exclude:
-                    if fnmatchcase(name, pattern) or fn.lower() == pattern.lower():
-                        bad_name = True
-                        if show_ignored:
-                            print(sys.stderr, (
-                                "File %s ignored by pattern %s"
-                                % (fn, pattern)))
-                        break
-                if bad_name:
-                    continue
-                out.setdefault(package, []).append(prefix + name)
-    return out
-
 
 setup(
     name='django-zerodowntime',
@@ -103,18 +18,17 @@ setup(
     author="Phil Plante",
     author_email='phil@rentlytics.com',
     url='https://github.com/rentlytics/django-zerodowntime',
-    packages=find_packages(exclude=['tests', 'tests.*']),
-    package_data=find_package_data(),
+    packages=[
+        'zerodowntime'
+    ],
+    include_package_data=True,
     install_requires=[
-        # Bleeding edge Django
         'django>=1.8',
-
-        # for deploy scripting
-        'invoke==0.13.0',
     ],
     setup_requires=[
         'pytest-runner',
     ],
+    test_suite='tests',
     tests_require=[
         'pytest',
         'pytest-django',

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,14 @@
 [tox]
 envlist =
     {py27,py35}-{1.8,1.10,master}
-;    py35-1.10
 
 [testenv]
-basepython =
-    py27: python2.7
-    py35: python3.5
-usedevelop = true
-pip_pre = true
-changedir=tests
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}/zerodowntime
 commands =
-    py.test --basetemp={envtmpdir} {posargs}
+    py.test --basetemp={envtmpdir}
 deps =
-    pytest
-    pytest-django
+    -r{toxinidir}/requirements_dev.txt
     1.8: Django>=1.8,<1.9
     1.10: Django<1.11
     master: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
Added instructions for running tests to `README.md`.  Now you can run `tox` to run the entire suite of tests against Python 2.7-3.5 and Django 1.8-1.10.  If you want a quicker test run just use `py.test`.