### PR TITLE
DP-1223: CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          python setup.py install
+          sudo python setup.py install
           sudo pip install tox
           python setup.py test
           tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,12 @@ jobs:
       - image: circleci/python:2.7
     steps:
       - checkout
-      - run: |
-          sudo python setup.py install
-          sudo pip install tox
-          sudo python setup.py test
-          sudo tox
+      - run: sudo pip install pyenv
+      - run: sudo pyenv global 2.7.11 3.5.1
+      - run: sudo python setup.py install
+      - run: sudo pip install tox
+      - run: sudo python setup.py test
+      - run: sudo tox
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
     steps:
       - checkout
       - run: |
-          pyenv global 2.7.11 3.5.1
           python setup.py install
           pip install tox
           python setup.py test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run: |
           python setup.py install
-          pip install tox
+          sudo pip install tox
           python setup.py test
           tox
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,9 @@ jobs:
       - image: circleci/python:2.7
     steps:
       - checkout
-      - run: sudo pip install pyenv
+      - run: sudo curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+      - run: pyenv update
+      - run: pyenv global 2.7.11 3.5.1
       - run: sudo pyenv global 2.7.11 3.5.1
       - run: sudo python setup.py install
       - run: sudo pip install tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:2.7
+    steps:
+      - checkout
+      - run: |
+          pyenv global 2.7.11 3.5.1
+          python setup.py install
+          pip install tox
+          python setup.py test
+          tox
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,11 @@ jobs:
       - image: circleci/python:2.7
     steps:
       - checkout
-      - run: sudo pip install --egg pyenv
+      - run: sudo pip install tox
       - run: pyenv update
       - run: pyenv global 2.7.11 3.5.1
       - run: sudo pyenv global 2.7.11 3.5.1
       - run: sudo python setup.py install
-      - run: sudo pip install tox
       - run: sudo python setup.py test
       - run: sudo tox
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.5
     steps:
       - checkout
       - run: sudo python setup.py install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           sudo python setup.py install
           sudo pip install tox
           sudo python setup.py test
-          tox
+          sudo tox
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,8 @@ jobs:
       - image: circleci/python:2.7
     steps:
       - checkout
-      - run: sudo pip install tox
-      - run: pyenv update
-      - run: pyenv global 2.7.11 3.5.1
-      - run: sudo pyenv global 2.7.11 3.5.1
       - run: sudo python setup.py install
+      - run: sudo pip install tox
       - run: sudo python setup.py test
       - run: sudo tox
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run: |
           sudo python setup.py install
           sudo pip install tox
-          python setup.py test
+          sudo python setup.py test
           tox
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: circleci/python:2.7
     steps:
       - checkout
-      - run: sudo curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+      - run: sudo pip install --egg pyenv
       - run: pyenv update
       - run: pyenv global 2.7.11 3.5.1
       - run: sudo pyenv global 2.7.11 3.5.1

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  post:
-    - pyenv global 2.7.11 3.5.1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'django==1.8',
+        'django>=1.8',
+        'django<2.0',
     ],
     setup_requires=[
         'pytest-runner',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'django>=1.8',
+        'django==1.11',
     ],
     setup_requires=[
         'pytest-runner',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'django==1.11',
+        'django==1.10',
     ],
     setup_requires=[
         'pytest-runner',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'django==1.10',
+        'django==1.8',
     ],
     setup_requires=[
         'pytest-runner',


### PR DESCRIPTION
DP-1223: CircleCI 2.0

* Based on the old circle.yml file, created a new .circleci/config.yml for version 2.0
* removed the old circle.yml file
* Added a setup dependency requirements statement to ensure django version 2.0 or higher are not used, as these break the tests due to versioning issues with other dependencies.
* pyenv is no longer used. Renovation Manager Team will investigate if it is needed, but they seem to think it is safe to remove for now if the tests are running and passing.