### PR TITLE
VA-None: Update django requirement in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'django>=1.11.17',
+        'django>=1.11.16',
         'django<1.12',
     ],
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'django>=1.8',
-        'django<2.0',
+        'django>=1.11.17',
+        'django<1.12',
     ],
     setup_requires=[
         'pytest-runner',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'django>=1.11.16',
+        'django>=1.11.15',
         'django<1.12',
     ],
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'django>=1.11.15',
+        'django>=1.8',
         'django<1.12',
     ],
     setup_requires=[


### PR DESCRIPTION
Github is reporting a (potential security vulnerability)[https://github.com/rentlytics/django-zerodowntime/network/dependencies] in setup.py since we're referencing django 2.0.  We're only referencing 2.0 to state we want a version <2.0, so I've updated that requirement to <1.12.

I think we may want to check a look at what this is checking in CircleCI.  Currently, this project is testing django 1.8 and 1.10 (versus 1.11).

(Sorry, I thought I had already opened this PR, but apparently, I failed to hit the "Create pull request" button.